### PR TITLE
Use _ as separator and flatten out disk elements

### DIFF
--- a/pyroll/export/__init__.py
+++ b/pyroll/export/__init__.py
@@ -16,4 +16,4 @@ CLI_INSTALLED = bool(importlib.util.find_spec("pyroll.cli"))
 if CLI_INSTALLED:
     from . import cli
 
-VERSION = "2.1.2"
+VERSION = "2.2.0"

--- a/pyroll/export/convert.py
+++ b/pyroll/export/convert.py
@@ -27,7 +27,7 @@ def _flatten_dict(d: dict[str, Any]) -> dict[Union[str, tuple[str, ...]], Any]:
             else:
                 yield prefix + (k,), v
 
-    return dict((".".join(k), v) for k, v in _gen(d))
+    return dict(("_".join(k), v) for k, v in _gen(d))
 
 
 @hookimpl(specname="convert")

--- a/pyroll/export/convert.py
+++ b/pyroll/export/convert.py
@@ -24,6 +24,9 @@ def _flatten_dict(d: dict[str, Any]) -> dict[Union[str, tuple[str, ...]], Any]:
         for k, v in d_.items():
             if isinstance(v, dict):
                 yield from _gen(v, prefix + (k,))
+            elif k == "disk_elements":
+                for i, de in enumerate(v):
+                    yield from _gen(de, prefix + (k, str(i)))
             else:
                 yield prefix + (k,), v
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -32,6 +32,7 @@ sequence = PassSequence([
             nominal_radius=160e-3,
             rotational_frequency=1
         ),
+        disk_element_count=3,
         gap=2e-3,
     ),
     Transport(


### PR DESCRIPTION
Close #3 

To improve usability of pandas export.

Minor version increment since it breaks old naming scheme.